### PR TITLE
Sugestão: Adicionar pylint-django nas confs do pylint

### DIFF
--- a/django_examples/fpftech_ads/.pylintrc
+++ b/django_examples/fpftech_ads/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+load-plugins=pylint_django


### PR DESCRIPTION
No meu ambiente o linter padrão do vscode dá erro quando usamos `Modelo.objects.all()`, a solução foi carregar o plugin do django no pylint.
Achava interesante ter um comitado no repo pra ficar como referência